### PR TITLE
Fix the import error when is executed out of the poetry shell

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -4,7 +4,9 @@ from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
 from alembic import context
-
+import sys
+import os
+sys.path.append(os.getcwd())
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config


### PR DESCRIPTION
Adding to the sys path from where is it executed the python, fix the error that cant find app module when you dont use poetry shell, and dont have to use the PYTHONPATH=. alembic revision --autogenerate...